### PR TITLE
Added help icon that when clicked leads to documentation

### DIFF
--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Remove from '../assets/remove.svg'
 import Edit from '../assets/edit.svg'
+import Help from '../assets/help.svg'
 import { updateArray } from '../utils/array.js'
 import './toolbar.css'
 
@@ -21,12 +22,17 @@ const editWebComponent = (e, props) => {
   props.setEditOptions(props.options);
 }
 
+const helpWebComponent = (e, props) => {
+  e.preventDefault();
+  const url = "https://github.com/mcclatchy/graphics-nocode/?tab=readme-ov-file"
+  window.open(url, 'blank');
+}
 
 class Toolbar extends React.Component {
   constructor(props) {
     super(props);
   }
-
+ 
   render() {
     return(
       <div className="card-toolbar">
@@ -39,6 +45,14 @@ class Toolbar extends React.Component {
           // TODO: figure out how to deal with dark mode in the tool better?
           // style={{filter: document.getElementById("link-dark") ? "invert(1)" : ""}}
         />
+         <img 
+          src={Help} 
+          alt="help"
+          onClick={(e) => { 
+            helpWebComponent(e, this.props);
+            
+          }}
+        />
         <img 
           src={Remove} 
           alt="remove"
@@ -46,6 +60,7 @@ class Toolbar extends React.Component {
             removeWebComponent(e, this.props); 
           }}
         />
+
       </div>
     )
   }

--- a/src/configs/menu-default.js
+++ b/src/configs/menu-default.js
@@ -1,6 +1,7 @@
 const menuDefault = {
     "themes": [],
-    "enhancements": [
+    
+    "enhancements": [ 
     {
         "type": "checkbox",
         "label": "makeMediaWide",


### PR DESCRIPTION
What does the PR do?

- Adds the help icon that when clicked leads to the documentation for the application

What problem does the new feature solve?

- The user would see no help icon and would have no way to get to the documentation from inside the application but instead would have to go to the home screen and select the Documentation button.

How does the code work?

How to test the feature:
Where is the feature branch deployed?

-  Pull from 2-help-icon for testing

What are the steps to test it?

- Click on the enhance button on the home screen. When the new screen loads select the +(plus) icon in the left panel for any enhancement. Then on the right three icons should appear. Select the icon that appears as a question mark and make sure it leads to the documentation.

Related ticket:
#2 