### PR TITLE
3 styling variable

### DIFF
--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Remove from '../assets/remove.svg'
 import Edit from '../assets/edit.svg'
+import Help from '../assets/help.svg'
 import { updateArray } from '../utils/array.js'
 import './toolbar.css'
 
@@ -21,12 +22,17 @@ const editWebComponent = (e, props) => {
   props.setEditOptions(props.options);
 }
 
+const helpWebComponent = (e, props) => {
+  e.preventDefault();
+  const url = "https://github.com/mcclatchy/graphics-nocode/?tab=readme-ov-file"
+  window.open(url, 'blank');
+}
 
 class Toolbar extends React.Component {
   constructor(props) {
     super(props);
   }
-
+ 
   render() {
     return(
       <div className="card-toolbar">
@@ -39,6 +45,14 @@ class Toolbar extends React.Component {
           // TODO: figure out how to deal with dark mode in the tool better?
           // style={{filter: document.getElementById("link-dark") ? "invert(1)" : ""}}
         />
+         <img 
+          src={Help} 
+          alt="help"
+          onClick={(e) => { 
+            helpWebComponent(e, this.props);
+            
+          }}
+        />
         <img 
           src={Remove} 
           alt="remove"
@@ -46,6 +60,7 @@ class Toolbar extends React.Component {
             removeWebComponent(e, this.props); 
           }}
         />
+
       </div>
     )
   }

--- a/src/configs/menu-default.js
+++ b/src/configs/menu-default.js
@@ -1,6 +1,7 @@
 const menuDefault = {
     "themes": [],
-    "enhancements": [
+    
+    "enhancements": [ 
     {
         "type": "checkbox",
         "label": "makeMediaWide",

--- a/src/configs/menu-dev.js
+++ b/src/configs/menu-dev.js
@@ -61,6 +61,25 @@ const menuDev = {
                     "value": "https://www.miamiherald.com/static/hi/2024/charlotte-sweet-16/images/banner.jpg",
                     "type": "text"
                 },
+                "--lead-image-object-position-horizontal-mobile": {
+                    "label": "Horizontal Position",
+                    "value": "50",
+                    "type": "range",
+                    "unit": "%",
+                    "min": "0",
+                    "max": "100",
+                    "property": ":root"
+                },
+                "--lead-image-object-position-vertical-mobile": {
+                    "label": "Vertical Position",
+                    "value": "50",
+                    "type": "range",
+                    "unit": "%",
+                    "min": "0",
+                    "max": "100",
+                    "property": ":root"
+                },
+                
                 "slot": {
                     "label": "Caption",
                     "options": ["figcaption"],
@@ -70,6 +89,7 @@ const menuDev = {
                     }],
                     "type": "text-item"
                 }
+                
             }
         },
         {


### PR DESCRIPTION
What does the PR do?

- Adds sliders within the lead image card to the edit icon which allows the user to change the image via horizontal and vertical sizing of the image in mobile screen view. Creates a new way to crop the image

What problem does the new feature solve?

- The user was not able to change this setting before. The image while on the mobile screen view would be oversized but can now be changed if needed

How does the code work?

How to test the feature:
Where is the feature branch deployed?

- Pull from branch 3-styling-variable for testing

What are the steps to test it?

- Use the correct version of graphics no code which includes the lead image card. In the left panel click the lead image plus sign. Then in the left panel at the top under profile select the mobile screen view which is the last one on the right. Under the lead image  in the middle that should have appeared you will see a pen that is next to the question mark which is the edit icon. Click this icon and you will see a screen with vertical and horizontal sliders appear, change one or both of them and click the X , and ensure the image changes based on the sliders.

Related ticket:
#3 